### PR TITLE
Resolve results as one object

### DIFF
--- a/lib/wav-audio-sprite.js
+++ b/lib/wav-audio-sprite.js
@@ -91,7 +91,7 @@ function wavAudioSprite(files) {
         const merged = mergeAudio(audioData);
         const encoded = wav.encode(merged.channelData, {sampleRate: merged.sampleRate});
 
-        return resolve(encoded, timings);
+        resolve({ encoded, timings });
     });
 }
 


### PR DESCRIPTION
Combine final results as one object in the resolve-method, instead of over multiple parameters